### PR TITLE
[TH2-5291] Improved log messages (`SenderCompId>/SenderSubId > TargetCompId[host:port]` prefix is printed)

### DIFF
--- a/.github/workflows/ci-unwelcome-words.yml
+++ b/.github/workflows/ci-unwelcome-words.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   test:
     if: github.actor != 'dependabot[bot]'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
         with:

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# th2-conn-dirty-fix (1.8.0)
+# th2-conn-dirty-fix (1.8.1)
 
 This microservice allows sending and receiving messages via FIX protocol
 
@@ -322,6 +322,12 @@ spec:
 ```
 
 # Changelog
+
+## 1.8.1
+
+* Improved log messages (`SenderCompId>/SenderSubId > TargetCompId[host:port]` prefix is printed)
+* Updated:
+  * grpc-lw-data-provider: `2.4.0-dev`
 
 ## 1.8.0
 * Migrated:

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
-release_version=1.8.0
+release_version=1.8.1
 description='Dirty FIX client'
 vcs_url=https://github.com/th2-net/th2-conn-dirty-fix

--- a/src/test/java/com/exactpro/th2/FixHandlerSendTimeoutTest.java
+++ b/src/test/java/com/exactpro/th2/FixHandlerSendTimeoutTest.java
@@ -57,6 +57,9 @@ class FixHandlerSendTimeoutTest {
                 .thenReturn(new CompletableFuture<>()); // future never completes
         var settings = new FixHandlerSettings();
         settings.setPort(42);
+        settings.setSenderCompID("test-sender-comp-id");
+        settings.setTargetCompID("test-target-comp-id");
+        settings.setPassword("test");
         settings.setHost("localhost");
         settings.setConnectionTimeoutOnSend(300); // 300 millis
         settings.setMinConnectionTimeoutOnSend(100);
@@ -74,7 +77,7 @@ class FixHandlerSendTimeoutTest {
                                     .build())
                             .build()));
             Assertions.assertEquals(
-                    "could not open connection before timeout 300 mls elapsed",
+                    "test-sender-comp-id > test-target-comp-id[localhost:42]: could not open connection before timeout 300 mls elapsed",
                     exception.getMessage(),
                     "unexpected message"
             );
@@ -99,6 +102,9 @@ class FixHandlerSendTimeoutTest {
                 .thenReturn(CompletableFuture.completedFuture(Unit.INSTANCE)); // completed immediately
         Mockito.when(channelMock.isOpen()).thenReturn(true);
         var settings = createSettings();
+        settings.setSenderCompID("test-sender-comp-id");
+        settings.setTargetCompID("test-target-comp-id");
+        settings.setPassword("test");
         Mockito.when(contextMock.getSettings())
                 .thenReturn(settings);
         try(var fixHandler = new FixHandler(contextMock)) {
@@ -113,7 +119,7 @@ class FixHandlerSendTimeoutTest {
                                     .build())
                             .build()));
             Assertions.assertEquals(
-                    "session was not established within 300 mls",
+                    "test-sender-comp-id > test-target-comp-id[localhost:42]: session was not established within 300 mls",
                     exception.getMessage(),
                     "unexpected message"
             );


### PR DESCRIPTION
* Updated grpc-lw-data-provider: `2.4.0-dev`